### PR TITLE
Add R2 as CDN

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ export class AppConfig {
 	public getConfig() {
 		return {
 			// supported services for API endpoints
-			SUPPORTED_SERVICES: ['/auth', '/context', '/database', '/scheduler', '/tools'],
+			SUPPORTED_SERVICES: ['/auth', '/cdn', '/context', '/database', '/scheduler', '/tools'],
 			// default interval for DO alarms
 			// set really high until we start using it
 			// can override in the durable object too

--- a/src/durable-objects/cdn-do.ts
+++ b/src/durable-objects/cdn-do.ts
@@ -1,0 +1,97 @@
+import { DurableObject } from '@cloudflare/workers-types';
+import { Env } from '../../worker-configuration';
+import { createJsonResponse } from '../utils/requests-responses';
+
+export class CdnDO extends DurableObject<Env> {
+    private readonly BASE_PATH = '/cdn';
+    private readonly SUPPORTED_ENDPOINTS: string[] = [
+        '/',  // For GET/POST/DELETE operations
+    ];
+
+    async fetch(request: Request): Promise<Response> {
+        const url = new URL(request.url);
+        const path = url.pathname;
+
+        if (!path.startsWith(this.BASE_PATH)) {
+            return createJsonResponse(
+                {
+                    error: `Request at ${path} does not start with base path ${this.BASE_PATH}`,
+                },
+                404
+            );
+        }
+
+        // Handle the request based on method
+        switch (request.method) {
+            case 'GET':
+                return this.handleGet(request);
+            case 'POST':
+                return this.handlePost(request);
+            case 'DELETE':
+                return this.handleDelete(request);
+            default:
+                return createJsonResponse(
+                    { error: 'Method not allowed' },
+                    405,
+                    { headers: { Allow: 'GET, POST, DELETE' } }
+                );
+        }
+    }
+
+    private async handleGet(request: Request): Promise<Response> {
+        const url = new URL(request.url);
+        const key = url.pathname.replace(this.BASE_PATH + '/', '');
+        
+        try {
+            const object = await this.env.AIBTCDEV_SERVICES_BUCKET.get(key);
+            
+            if (!object) {
+                return createJsonResponse({ error: 'Object not found' }, 404);
+            }
+
+            // Return the object with appropriate headers
+            return new Response(object.body, {
+                headers: {
+                    'content-type': object.httpMetadata?.contentType || 'application/octet-stream',
+                    'etag': object.httpEtag,
+                    'cache-control': object.httpMetadata?.cacheControl || 'public, max-age=31536000',
+                }
+            });
+        } catch (error) {
+            return createJsonResponse({ error: 'Failed to retrieve object' }, 500);
+        }
+    }
+
+    private async handlePost(request: Request): Promise<Response> {
+        // TODO: Add authentication check here
+        
+        const url = new URL(request.url);
+        const key = url.pathname.replace(this.BASE_PATH + '/', '');
+        
+        try {
+            const object = await this.env.AIBTCDEV_SERVICES_BUCKET.put(key, request.body, {
+                httpMetadata: {
+                    contentType: request.headers.get('content-type') || 'application/octet-stream',
+                }
+            });
+            
+            return createJsonResponse({ success: true, key, etag: object.httpEtag });
+        } catch (error) {
+            return createJsonResponse({ error: 'Failed to store object' }, 500);
+        }
+    }
+
+    private async handleDelete(request: Request): Promise<Response> {
+        // TODO: Add authentication check here
+        
+        const url = new URL(request.url);
+        const key = url.pathname.replace(this.BASE_PATH + '/', '');
+        
+        try {
+            await this.env.AIBTCDEV_SERVICES_BUCKET.delete(key);
+            return createJsonResponse({ success: true, key });
+        } catch (error) {
+            return createJsonResponse({ error: 'Failed to delete object' }, 500);
+        }
+    }
+}

--- a/src/durable-objects/index.ts
+++ b/src/durable-objects/index.ts
@@ -1,0 +1,6 @@
+export * from './auth-do';
+export * from './cdn-do';
+export * from './context-do';
+export * from './database-do';
+export * from './scheduler-do';
+export * from './tools-do';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 import { Env } from '../worker-configuration';
 import { AppConfig } from './config';
 import { corsHeaders, createJsonResponse } from './utils/requests-responses';
-import { AuthDO } from './durable-objects/auth-do';
-import { ContextDO } from './durable-objects/context-do';
-import { DatabaseDO } from './durable-objects/database-do';
-import { SchedulerDO } from './durable-objects/scheduler-do';
-import { ToolsDO } from './durable-objects/tools-do';
-import { CdnDO } from './durable-objects/cdn-do';
+import { AuthDO, CdnDO, ContextDO, DatabaseDO, SchedulerDO, ToolsDO } from './durable-objects';
 
 // export the Durable Object classes we're using
 export { AuthDO, ContextDO, DatabaseDO, SchedulerDO, ToolsDO, CdnDO };
@@ -47,6 +42,12 @@ export default {
 			return await stub.fetch(request); // forward the request to the Durable Object
 		}
 
+		if (path.startsWith('/cdn')) {
+			let id: DurableObjectId = env.CDN_DO.idFromName('cdn-do'); // create the instance
+			let stub = env.CDN_DO.get(id); // get the stub for communication
+			return await stub.fetch(request); // forward the request to the Durable Object
+		}
+
 		if (path.startsWith('/context')) {
 			const id: DurableObjectId = env.CONTEXT_DO.idFromName('context-do'); // create the instance
 			const stub = env.CONTEXT_DO.get(id); // get the stub for communication
@@ -68,12 +69,6 @@ export default {
 		if (path.startsWith('/tools')) {
 			let id: DurableObjectId = env.TOOLS_DO.idFromName('tools-do'); // create the instance
 			let stub = env.TOOLS_DO.get(id); // get the stub for communication
-			return await stub.fetch(request); // forward the request to the Durable Object
-		}
-
-		if (path.startsWith('/cdn')) {
-			let id: DurableObjectId = env.CDN_DO.idFromName('cdn-do'); // create the instance
-			let stub = env.CDN_DO.get(id); // get the stub for communication
 			return await stub.fetch(request); // forward the request to the Durable Object
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,10 @@ import { ContextDO } from './durable-objects/context-do';
 import { DatabaseDO } from './durable-objects/database-do';
 import { SchedulerDO } from './durable-objects/scheduler-do';
 import { ToolsDO } from './durable-objects/tools-do';
+import { CdnDO } from './durable-objects/cdn-do';
 
 // export the Durable Object classes we're using
-export { AuthDO, ContextDO, DatabaseDO, SchedulerDO, ToolsDO };
+export { AuthDO, ContextDO, DatabaseDO, SchedulerDO, ToolsDO, CdnDO };
 
 export default {
 	/**
@@ -67,6 +68,12 @@ export default {
 		if (path.startsWith('/tools')) {
 			let id: DurableObjectId = env.TOOLS_DO.idFromName('tools-do'); // create the instance
 			let stub = env.TOOLS_DO.get(id); // get the stub for communication
+			return await stub.fetch(request); // forward the request to the Durable Object
+		}
+
+		if (path.startsWith('/cdn')) {
+			let id: DurableObjectId = env.CDN_DO.idFromName('cdn-do'); // create the instance
+			let stub = env.CDN_DO.get(id); // get the stub for communication
 			return await stub.fetch(request); // forward the request to the Durable Object
 		}
 

--- a/src/utils/auth-helper.ts
+++ b/src/utils/auth-helper.ts
@@ -1,42 +1,39 @@
-import { DurableObject } from '@cloudflare/workers-types';
 import { Env } from '../../worker-configuration';
 
-export async function validateDurableObjectAuth(
-    env: Env,
-    request: Request
-): Promise<{ success: boolean; error?: string; status?: number }> {
-    if (!request.headers.has('Authorization')) {
-        return { success: false, error: 'Missing Authorization header', status: 401 };
-    }
+type SharedKeyResponse = { success: boolean; error?: string; status?: number };
 
-    const frontendKey = await env.AIBTCDEV_SERVICES_KV.get('key:aibtcdev-frontend');
-    const backendKey = await env.AIBTCDEV_SERVICES_KV.get('key:aibtcdev-backend');
+export async function validateSharedKeyAuth(env: Env, request: Request): Promise<SharedKeyResponse> {
+	if (!request.headers.has('Authorization')) {
+		return { success: false, error: 'Missing Authorization header', status: 401 };
+	}
 
-    if (frontendKey === null || backendKey === null) {
-        return {
-            success: false,
-            error: 'Unable to load shared keys for frontend/backend',
-            status: 401,
-        };
-    }
+	const frontendKey = await env.AIBTCDEV_SERVICES_KV.get('key:aibtcdev-frontend');
+	const backendKey = await env.AIBTCDEV_SERVICES_KV.get('key:aibtcdev-backend');
 
-    const validKeys = [frontendKey, backendKey];
-    const requestKey = request.headers.get('Authorization');
+	if (frontendKey === null || backendKey === null) {
+		return {
+			success: false,
+			error: 'Unable to load shared keys for frontend/backend',
+			status: 401,
+		};
+	}
 
-    if (requestKey === null || !validKeys.includes(requestKey)) {
-        return { success: false, error: 'Invalid Authorization key', status: 401 };
-    }
+	const validKeys = [frontendKey, backendKey];
+	const requestKey = request.headers.get('Authorization');
 
-    return { success: true };
+	if (requestKey === null || !validKeys.includes(requestKey)) {
+		return { success: false, error: 'Invalid Authorization key', status: 401 };
+	}
+
+	return { success: true };
 }
 
-export async function validateSessionToken(
-    env: Env,
-    sessionToken: string
-): Promise<{ success: boolean; address?: string; error?: string }> {
-    const address = await env.AIBTCDEV_SERVICES_KV.get(`auth:session:${sessionToken}`);
-    if (!address) {
-        return { success: false, error: 'Invalid or expired session token' };
-    }
-    return { success: true, address };
+type SessionTokenResponse = { success: boolean; address?: string; error?: string };
+
+export async function validateSessionToken(env: Env, sessionToken: string): Promise<SessionTokenResponse> {
+	const address = await env.AIBTCDEV_SERVICES_KV.get(`auth:session:${sessionToken}`);
+	if (!address) {
+		return { success: false, error: 'Invalid or expired session token' };
+	}
+	return { success: true, address };
 }

--- a/src/utils/auth-helper.ts
+++ b/src/utils/auth-helper.ts
@@ -1,0 +1,42 @@
+import { DurableObject } from '@cloudflare/workers-types';
+import { Env } from '../../worker-configuration';
+
+export async function validateDurableObjectAuth(
+    env: Env,
+    request: Request
+): Promise<{ success: boolean; error?: string; status?: number }> {
+    if (!request.headers.has('Authorization')) {
+        return { success: false, error: 'Missing Authorization header', status: 401 };
+    }
+
+    const frontendKey = await env.AIBTCDEV_SERVICES_KV.get('key:aibtcdev-frontend');
+    const backendKey = await env.AIBTCDEV_SERVICES_KV.get('key:aibtcdev-backend');
+
+    if (frontendKey === null || backendKey === null) {
+        return {
+            success: false,
+            error: 'Unable to load shared keys for frontend/backend',
+            status: 401,
+        };
+    }
+
+    const validKeys = [frontendKey, backendKey];
+    const requestKey = request.headers.get('Authorization');
+
+    if (requestKey === null || !validKeys.includes(requestKey)) {
+        return { success: false, error: 'Invalid Authorization key', status: 401 };
+    }
+
+    return { success: true };
+}
+
+export async function validateSessionToken(
+    env: Env,
+    sessionToken: string
+): Promise<{ success: boolean; address?: string; error?: string }> {
+    const address = await env.AIBTCDEV_SERVICES_KV.get(`auth:session:${sessionToken}`);
+    if (!address) {
+        return { success: false, error: 'Invalid or expired session token' };
+    }
+    return { success: true, address };
+}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,4 +8,6 @@ export interface Env {
 	SCHEDULER_DO: DurableObjectNamespace<import('./src/index').SchedulerDO>;
 	TOOLS_DO: DurableObjectNamespace<import('./src/index').ToolsDO>;
 	AIBTCDEV_SERVICES_DB: D1Database;
+	CDN_DO: DurableObjectNamespace<import('./src/index').CdnDO>;
+	AIBTCDEV_SERVICES_BUCKET: R2Bucket;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -57,3 +57,7 @@ id = "8a1d0cb7054d462e841fc7a70f820b8c"
 binding = "AIBTCDEV_SERVICES_DB"
 database_name = "aibtcdev-d1"
 database_id = "3b6d3694-0bb2-4c94-bca6-c62b62c1ec6f"
+
+[[r2_buckets]]
+binding = "AIBTCDEV_SERVICES_BUCKET"
+bucket_name = "aibtcdev-r2"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -44,8 +44,8 @@ class_name = "ToolsDO"
 # Durable Object migrations.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
 [[migrations]]
-tag = "v1"
-new_classes = ["AuthDO", "ContextDO", "DatabaseDO", "SchedulerDO", "ToolsDO"]
+tag = "v2"
+new_classes = ["AuthDO", "ContextDO", "DatabaseDO", "SchedulerDO", "ToolsDO", "CdnDO"]
 
 # Bind a KV Namespace. Use KV as persistent storage for small key-value pairs.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#kv-namespaces
@@ -57,6 +57,10 @@ id = "8a1d0cb7054d462e841fc7a70f820b8c"
 binding = "AIBTCDEV_SERVICES_DB"
 database_name = "aibtcdev-d1"
 database_id = "3b6d3694-0bb2-4c94-bca6-c62b62c1ec6f"
+
+[[durable_objects.bindings]]
+name = "CDN_DO"
+class_name = "CdnDO"
 
 [[r2_buckets]]
 binding = "AIBTCDEV_SERVICES_BUCKET"


### PR DESCRIPTION
This adds a new durable object that allows access to an R2 bucket for GET, LIST, PUT, and DELETE operations.

First one is a GET request `/cdn/get` and is open to anyone to call.

Other 3 are POST requests that require the shared key auth.

Untested and experimental but a step in the right direction!